### PR TITLE
RE-1190 Fix wrong branch used

### DIFF
--- a/osa_differ/osa_differ.py
+++ b/osa_differ/osa_differ.py
@@ -37,8 +37,6 @@ from . import exceptions
 # Configure logging
 log = logging.getLogger()
 log.setLevel(logging.ERROR)
-stdout_handler = logging.StreamHandler(sys.stdout)
-log.addHandler(stdout_handler)
 
 
 def create_parser():

--- a/tests/test_osa_differ.py
+++ b/tests/test_osa_differ.py
@@ -1,6 +1,7 @@
 """Testing osa-differ."""
 import argparse
 import json
+import os
 import subprocess
 
 
@@ -134,6 +135,22 @@ novncproxy_git_project_group: nova_console
         projects = osa_differ.get_projects(path,
                                            'HEAD')
         assert isinstance(projects, list)
+
+    def test_checkout(self, tmpdir):
+        """Test the checkout method."""
+        p = tmpdir.mkdir('test_checkout')
+        path = str(p)
+        repo = Repo.init(path)
+        file = p / "file"
+        file.write_text(u"foo", encoding='utf-8')
+        sfile = str(file)
+        assert os.path.exists(sfile)
+        repo.index.add(["file"])
+        repo.index.commit("Test")
+        sha = repo.head.commit.hexsha
+        os.remove(sfile)
+        osa_differ.checkout(repo, sha)
+        assert os.path.exists(sfile)
 
     def test_get_roles(self, tmpdir):
         """Verify that we can get OSA role information."""


### PR DESCRIPTION
FETCH_HEAD is a git ref that points to the last thing that was fetched.
This is useful when a single ref has been fetched, however it is
unreliable when multiple refs have been fetched.

Before this commit, a reset --hard FETCH_HEAD was issued after fetching.
This will have moved the currently checkout branch to
one of the fetched refs, which one is non deterministic.
This commit removes the erroneous checkout.

However even without a rogue reset, there may be old local branches from
previous runs of osa_differ, so this commit also removes local branches
before checking out a branch of the same name. This ensures git will
use it's logic to find the upstream branch and create a local branch
from that.

Previously reset was used, which doesn't have the same logic for
finding matching remote branches, so this commit switches to checkout.